### PR TITLE
提高 promise 的性能

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,27 +1,28 @@
 {
-  "name": "promise",
-  "version": "1.0.2",
-  "description": "A promise respecting ES standard with plenty of handy extensions",
-  "main": "main.js",
-  "author": "d_xinxin@163.com",
-  "homepage": "https://github.com/ecomfe/promise",
-  "repository": "https://github.com/ecomfe/promise",
-  "license": "BSD",
-  "readme": "README.md",
-  "scripts": {
-      "test": "node test/run.js"
-  },
-  "edp": {
-    "wwwroot": "/",
-    "depDir": "dep",
-    "srcDir": "src",
-    "loaderAutoConfig": "js,htm,html,tpl,vm,phtml",
-    "loaderUrl": "http://s1.bdstatic.com/r/www/cache/ecom/esl/1-8-2/esl.js"
-  },
-  "devDependencies": {
-    "mocha": "^1.21.4",
-    "promises-aplus-tests": "^2.0.4",
-    "sinon": "^1.10.3",
-    "underscore": "^1.6.0"
-  }
+    "name": "promise",
+    "version": "1.0.2",
+    "description": "A promise respecting ES standard with plenty of handy extensions",
+    "main": "src/main.js",
+    "author": "d_xinxin@163.com",
+    "homepage": "https://github.com/ecomfe/promise",
+    "repository": "https://github.com/ecomfe/promise",
+    "license": "MIT",
+    "readme": "README.md",
+    "scripts": {
+        "test": "node test/run.js"
+    },
+    "edp": {
+      "wwwroot": "/",
+      "depDir": "dep",
+      "main": "main.js",
+      "srcDir": "src",
+      "loaderAutoConfig": "js,htm,html,tpl,vm,phtml",
+      "loaderUrl": "http://s1.bdstatic.com/r/www/cache/ecom/esl/1-8-2/esl.js"
+    },
+    "devDependencies": {
+      "mocha": "^1.21.4",
+      "promises-aplus-tests": "^2.0.4",
+      "sinon": "^1.10.3",
+      "underscore": "^1.6.0"
+    }
 }

--- a/src/PromiseCapacity.js
+++ b/src/PromiseCapacity.js
@@ -39,12 +39,6 @@ void function (define) {
                 this.invoke = setImmediate;
             }
 
-            PromiseCapacity.onResolve = function (value) {};
-            PromiseCapacity.onReject = function (reason) {
-                typeof console !== 'undefined' && console.error(reason);
-            };
-
-
             PromiseCapacity.prototype = {
                 constructor: PromiseCapacity,
 
@@ -65,7 +59,7 @@ void function (define) {
                         // reject promise with e as the reason
                         var then = u.getThen(value);
                         if (typeof then === 'function') {
-                            chain(u.bind(then, value), this);
+                            chain(u.bindThen(then, value), this);
                             return;
                         }
                     }
@@ -81,8 +75,7 @@ void function (define) {
                     this.result = value;
                     this.status = FULFILLED;
 
-                    this.constructor.onResolve.call(this.promise, value);
-
+                    onResolve(this.promise, value);
                     exec(this);
                 },
 
@@ -94,8 +87,7 @@ void function (define) {
                     this.result = obj;
                     this.status = REJECTED;
 
-                    this.constructor.onReject.call(this.promise, obj);
-
+                    onReject(this.promise, obj);
                     exec(this);
                 },
 
@@ -187,6 +179,16 @@ void function (define) {
                         callback(val);
                     }
                 });
+            }
+
+            function onResolve(promise, value) {
+                var onResolve = promise.constructor.onResolve;
+                typeof onResolve === 'function' && onResolve(promise, value);
+            }
+
+            function onReject(promise, reason) {
+                var onReject = promise.constructor.onReject;
+                typeof onReject === 'function' && onReject(promise, reason);
             }
 
             return PromiseCapacity;

--- a/src/hook.js
+++ b/src/hook.js
@@ -9,38 +9,17 @@ void function (define) {
     define(
         function (require) {
 
-            var PromiseCapacity = require('./PromiseCapacity');
-
             return function (Promise) {
-
-                /**
-                 * 设置 promise reject 时的回调
-                 *
-                 * @param {Function} handler 回调函数，作用域指向当前的 promise，传入值为 reject reason
-                 */
-                Promise.onReject = function (handler) {
-                    if (typeof handler === 'function') {
-                        PromiseCapacity.onReject = handler;
-                    }
+                // 加个默认的错误钩子先
+                Promise.onReject = function (reason) {
+                    typeof console !== 'undefined' && console.error(reason);
                 };
-
-                 /**
-                 * 设置 promise resolve 时的回调
-                 *
-                 * @param {Function} handler 回调函数，作用域指向当前的 promise，传入值为 resolve value
-                 */
-                Promise.onResolve = function (handler) {
-                    if (typeof handler === 'function') {
-                        PromiseCapacity.onResolve = handler;
-                    }
-                };
-
                 return Promise;
             }
         }
     );
 
-  /* eslint-disable brace-style */
-  /* global module: true */
+    /* eslint-disable brace-style */
+    /* global module: true */
 }(typeof define === 'function' && define.amd ? define
     : function (factory) { module.exports = factory(require); }, this);

--- a/src/setImmediate.js
+++ b/src/setImmediate.js
@@ -45,11 +45,13 @@ void function (define) {
             //
             // 主要参考自https://github.com/YuzuJS/setImmediate
             if (typeof global.setImmediate === 'function') {
-                return require('./util').bind(global.setImmediate, global);
+                return function (fn) {
+                    global.setImmediate(fn);
+                };
             }
 
-            if (typeof global.nextTick === 'function') {
-                return global.nextTick;
+            if (typeof process !== 'undefined' && typeof process.nextTick === 'function') {
+                return process.nextTick;
             }
 
             if (global.MutationObserver || global.webKitMutationObserver) {
@@ -70,7 +72,7 @@ void function (define) {
                     // 从异步来说，每个callstack应该只执行一个函数，因此这里不能共享`MutationObserver`实例，
                     // 共享的情况下，由于浏览器使用的是microtask queue，会让多次变更在一次回调中体现，导致无法保持单独的callstack
                     var observer = new MutationObserver(ensureElementMutation);
-                    observer.observe(element, { attributes: true });
+                    observer.observe(element, {attributes: true});
 
                     var tick = registerCallback(callback);
                     element.setAttribute(ATTRIBUTE_NAME, tick);
@@ -83,7 +85,7 @@ void function (define) {
                 // 部分IE的`postMessage`的`callback`是同步触发的，要去掉这一批
                 var isPostMessageAsync = true;
                 var oldListener = global.onmessage;
-                global.onmessage = function() {
+                global.onmessage = function () {
                     isPostMessageAsync = false;
                 };
                 global.postMessage('', '*');

--- a/src/util.js
+++ b/src/util.js
@@ -54,6 +54,12 @@ void function (define) {
                 return promise && (typeof promise === 'object' || typeof promise === 'function') && promise.then;
             };
 
+            util.bindThen = function (then, thenable) {
+                return function (fulfilled, rejected) {
+                    return then.call(thenable, fulfilled, rejected);
+                }
+            };
+
             return util;
         }
     );

--- a/test/run.js
+++ b/test/run.js
@@ -5,7 +5,7 @@ var fs = require("fs");
 var _ = require("underscore");
 
 // 先覆盖掉默认的打印函数
-Promise.onReject(function () {});
+Promise.onReject = null;
 
 var adapter = {
     resolved: function (v) {

--- a/test/spec/hook.js
+++ b/test/spec/hook.js
@@ -6,10 +6,10 @@ describe("Promise hook test.", function () {
     specify("onResolve test", function (done) {
         var result = null;
         var called = false;
-        Promise.onResolve(function (value) {
+        Promise.onResolve = function (promise, value) {
             result = value;
             called = true;
-        });
+        };
 
         var promise = Promise.resolve({});
 
@@ -29,10 +29,10 @@ describe("Promise hook test.", function () {
     specify("onReject test", function (done) {
         var result = null;
         var called = false;
-        Promise.onReject(function (value) {
+        Promise.onReject = function (promise, value) {
             result = value;
             called = true;
-        });
+        };
 
         var promise = Promise.reject({});
 


### PR DESCRIPTION
- 性能优化（10w次 resolve 调用，未改进前为2400ms左右，现为1050左右，大约提高60%）
- hook 调用改为赋值形式
